### PR TITLE
Update rover trigger handling

### DIFF
--- a/Assets/RoverController.cs
+++ b/Assets/RoverController.cs
@@ -82,18 +82,13 @@ public class RoverController : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
+        if (!collision.CompareTag("MiningZone"))
+            return;
+
         Debug.Log($"RoverController: Trigger entered with {collision.name}");
-        if (collision.CompareTag("MiningZone"))
-        {
-            Debug.Log("Mining zone found");
-            miningDrill.enabled = true;
-            inMiningZone = true;
-        } else
-        {
-            Debug.Log("Not a mining zone, disabling drill");
-            miningDrill.enabled = false;
-            inMiningZone = false;
-        }
+        Debug.Log("Mining zone found");
+        miningDrill.enabled = true;
+        inMiningZone = true;
     }
 
     private void OnTriggerExit2D(Collider2D collision)


### PR DESCRIPTION
## Summary
- activate the mining drill only when entering `MiningZone`
- ignore other colliders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68661e86e1cc832c98c297f0bf3f0388