### PR TITLE
Enable painter when mining begins

### DIFF
--- a/Assets/Code/MenuManager.cs
+++ b/Assets/Code/MenuManager.cs
@@ -31,7 +31,6 @@ public class MenuManager : MonoBehaviour
     [Header("Input control")]
     [SerializeField] private PlayerInput rocketInput;
     [SerializeField] private PlayerInput roverInput;
-    [SerializeField] private PlayerInput drillInput;
 
     [SerializeField] private ModManager modManager;
     [SerializeField] private ModActionPanel modActionPanel;
@@ -193,7 +192,7 @@ public class MenuManager : MonoBehaviour
             camFollow.SnapToTargetSmooth(1f); // You can set any transition duration
         }
 
-        // Cambia el tamaÒo de la c·mara con DOTween
+        // Cambia el tama√±o de la c√°mara con DOTween
         if (menuCamera != null)
             menuCamera.DOOrthoSize(16f, 1f);
 

--- a/Assets/RoverController.cs
+++ b/Assets/RoverController.cs
@@ -89,6 +89,8 @@ public class RoverController : MonoBehaviour
         Debug.Log("Mining zone found");
         miningDrill.enabled = true;
         inMiningZone = true;
+        if (MiningManager.Instance != null)
+            MiningManager.Instance.EnablePainter(true);
     }
 
     private void OnTriggerExit2D(Collider2D collision)


### PR DESCRIPTION
## Summary
- activate the dirt painter when entering the mining zone
- remove an unused input reference from `MenuManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68662122fbd4832c9b86a4e7b7569e6f